### PR TITLE
haxe 4 don't parse `function () { } (e)` as a call anymore

### DIFF
--- a/src/thx/stream/Stream.hx
+++ b/src/thx/stream/Stream.hx
@@ -288,7 +288,7 @@ class Stream<T> {
           return false;
         return flag = true;
       };
-    }()));
+    })());
 
   public function take(qt: Int) {
     if(qt < 0)
@@ -340,7 +340,7 @@ class Stream<T> {
           return true;
         return flag = false;
       };
-    }()));
+    })());
 
   public function comp(compare: T -> T -> Bool): Stream<T>
     return Stream.create(function(o) {


### PR DESCRIPTION
see https://github.com/HaxeFoundation/haxe/issues/5854
if you want that then you have to use (function(p) {}) (e);
this seems to be backward compatible